### PR TITLE
Add bulk team generation modal for clubs and leagues

### DIFF
--- a/ligas/forms.py
+++ b/ligas/forms.py
@@ -1,0 +1,15 @@
+from django import forms
+
+from .models import Club, Liga
+
+
+class EquipoGenerateForm(forms.Form):
+    club = forms.ModelChoiceField(
+        queryset=Club.objects.all().order_by("nombre"),
+        label="Club",
+    )
+    liga = forms.ModelChoiceField(
+        queryset=Liga.objects.all().order_by("-temporada", "nombre"),
+        label="Liga",
+        help_text="Se crearán equipos para todas las categorías asociadas a la liga seleccionada.",
+    )

--- a/ligas/templates/ligas/administracion/equipo_generate_modal.html
+++ b/ligas/templates/ligas/administracion/equipo_generate_modal.html
@@ -1,0 +1,9 @@
+<form method="post" action="{{ request.get_full_path }}">
+  {% csrf_token %}
+  <p>Seleccione un club y una liga. Se crearán equipos para cada categoría de la liga usando el nombre "Club - Categoría".</p>
+  {{ form.as_p }}
+  <div style="margin-top:12px; display:flex; gap:8px;">
+    <button class="btn primary" type="submit">Generar</button>
+    <button class="btn" type="button" data-modal-close>Cancelar</button>
+  </div>
+</form>

--- a/ligas/templates/ligas/administracion/equipo_list.html
+++ b/ligas/templates/ligas/administracion/equipo_list.html
@@ -8,6 +8,7 @@
     <button class="btn" type="submit">Buscar</button>
   </form>
   {% if perms.ligas.add_equipo %}
+    <a class="btn js-open-modal" data-modal-title="Generar equipos" href="{% url 'ligas:equipo_generate' %}">Generar</a>
     <a class="btn primary js-open-modal" data-modal-title="Nuevo equipo" href="{% url 'ligas:equipo_create' %}">Nuevo equipo</a>
   {% endif %}
 {% endblock %}

--- a/ligas/tests.py
+++ b/ligas/tests.py
@@ -1,3 +1,66 @@
+from django.contrib.auth.models import Permission, User
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Categoria, Club, Equipo, Liga
+
+
+class EquipoGenerateViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="tester",
+            password="testpass123",
+            is_staff=True,
+        )
+        permission = Permission.objects.get(codename="add_equipo")
+        self.user.user_permissions.add(permission)
+        self.client.login(username="tester", password="testpass123")
+
+        self.club = Club.objects.create(nombre="Club Generador")
+        self.liga = Liga.objects.create(nombre="Liga Test", temporada="2024")
+        self.categoria_a = Categoria.objects.create(liga=self.liga, nombre="Sub 10")
+        self.categoria_b = Categoria.objects.create(liga=self.liga, nombre="Sub 12")
+
+    def test_generate_creates_equipo_for_all_categories(self):
+        response = self.client.post(
+            reverse("ligas:equipo_generate"),
+            {"club": self.club.id, "liga": self.liga.id},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("ligas:equipo_list"),
+            fetch_redirect_response=False,
+        )
+
+        equipos = Equipo.objects.filter(club=self.club, categoria__liga=self.liga)
+        self.assertEqual(equipos.count(), 2)
+        self.assertEqual(
+            equipos.get(categoria=self.categoria_a).alias,
+            f"{self.club.nombre} - {self.categoria_a.nombre}",
+        )
+
+    def test_generate_skips_existing_equipo(self):
+        Equipo.objects.create(club=self.club, categoria=self.categoria_a, alias="Personalizado")
+
+        response = self.client.post(
+            reverse("ligas:equipo_generate"),
+            {"club": self.club.id, "liga": self.liga.id},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("ligas:equipo_list"),
+            fetch_redirect_response=False,
+        )
+
+        equipos = Equipo.objects.filter(club=self.club, categoria__liga=self.liga)
+        self.assertEqual(equipos.count(), 2)
+        self.assertEqual(
+            equipos.get(categoria=self.categoria_a).alias,
+            "Personalizado",
+        )
+        self.assertEqual(
+            equipos.get(categoria=self.categoria_b).alias,
+            f"{self.club.nombre} - {self.categoria_b.nombre}",
+        )

--- a/ligas/urls.py
+++ b/ligas/urls.py
@@ -8,7 +8,7 @@ from .abm_views import (
     TorneoListView, TorneoCreateView, TorneoUpdateView, TorneoDeleteView,
     RondaListView, RondaCreateView, RondaUpdateView, RondaDeleteView,
     CategoriaListView, CategoriaCreateView, CategoriaUpdateView, CategoriaDeleteView,
-    EquipoListView, EquipoCreateView, EquipoUpdateView, EquipoDeleteView,
+    EquipoListView, EquipoCreateView, EquipoGenerateView, EquipoUpdateView, EquipoDeleteView,
     EquipoDetailView,
     JugadorListView, JugadorCreateView, JugadorUpdateView, JugadorDeleteView,
     ArbitroListView, ArbitroCreateView, ArbitroUpdateView, ArbitroDeleteView,
@@ -50,6 +50,7 @@ urlpatterns = [
     path("administracion/categorias/<int:pk>/eliminar/", CategoriaDeleteView.as_view(), name="categoria_delete"),
 
     path("administracion/equipos/", EquipoListView.as_view(), name="equipo_list"),
+    path("administracion/equipos/generar/", EquipoGenerateView.as_view(), name="equipo_generate"),
     path("administracion/equipos/<int:pk>/", EquipoDetailView.as_view(), name="equipo_detail"),
     path("administracion/equipos/nuevo/", EquipoCreateView.as_view(), name="equipo_create"),
     path("administracion/equipos/<int:pk>/editar/", EquipoUpdateView.as_view(), name="equipo_update"),


### PR DESCRIPTION
## Summary
- add a modal form to generate teams for a club and liga using existing categories
- create backend view, form and template to bulk create teams with default aliases
- cover the generation workflow with unit tests and expose the action in the equipos list

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d3f4132c408325b5e16cce4ed1b5d4