### PR TITLE
Enhance admin tables with sorting and filtering

### DIFF
--- a/ligas/static/ligas/admin-tables.js
+++ b/ligas/static/ligas/admin-tables.js
@@ -1,0 +1,200 @@
+(function(){
+  const BOOLEAN_TRUE = new Set(['si', 'true', '1', 'activo', 'activa']);
+  const BOOLEAN_FALSE = new Set(['no', 'false', '0', 'inactivo', 'inactiva']);
+
+  function normalizeText(value) {
+    let text = (value || '').toString();
+    if (text.normalize) {
+      text = text
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+    }
+    return text.toLowerCase().trim();
+  }
+
+  function parseBooleanValue(text) {
+    const normalized = normalizeText(text);
+    if (BOOLEAN_TRUE.has(normalized)) return 'true';
+    if (BOOLEAN_FALSE.has(normalized)) return 'false';
+    return normalized;
+  }
+
+  function getSortValue(cell, type) {
+    if (!cell) return '';
+    const dataValue = cell.getAttribute('data-sort-value');
+    if (dataValue !== null) return dataValue;
+    const raw = cell.textContent || '';
+    if (type === 'boolean') {
+      return parseBooleanValue(raw) === 'true' ? '1' : '0';
+    }
+    return normalizeText(raw);
+  }
+
+  function initTable(table) {
+    if (!table || table.dataset.enhanced === '1') return;
+    const thead = table.tHead;
+    const tbody = table.tBodies[0];
+    if (!thead || !tbody) return;
+    const headerRow = thead.rows[0];
+    if (!headerRow) return;
+
+    const headers = Array.from(headerRow.cells);
+    if (!headers.length) return;
+
+    const filterRow = thead.insertRow(1);
+    filterRow.classList.add('table-filters');
+
+    const filterConfigs = [];
+    const sortTypes = [];
+    let dataRows = Array.from(tbody.rows).filter(row => !row.classList.contains('empty-row'));
+    const defaultOrder = dataRows.slice();
+    const emptyRow = Array.from(tbody.rows).find(row => row.classList.contains('empty-row'));
+    const currentSort = { index: null, dir: null };
+
+    function applyFilters() {
+      let visibleCount = 0;
+      dataRows.forEach(row => {
+        let visible = true;
+        for (const cfg of filterConfigs) {
+          const cell = row.cells[cfg.index];
+          const text = cell ? cell.textContent || '' : '';
+          if (cfg.type === 'text') {
+            const query = normalizeText(cfg.getValue());
+            if (query && normalizeText(text).indexOf(query) === -1) {
+              visible = false;
+              break;
+            }
+          } else if (cfg.type === 'boolean') {
+            const selected = cfg.getValue();
+            if (selected && parseBooleanValue(text) !== selected) {
+              visible = false;
+              break;
+            }
+          }
+        }
+        row.style.display = visible ? '' : 'none';
+        if (visible) visibleCount += 1;
+      });
+      if (emptyRow) {
+        emptyRow.style.display = visibleCount ? 'none' : '';
+      }
+    }
+
+    function setSortIndicators(index, direction) {
+      headers.forEach((th, idx) => {
+        th.classList.remove('sorted-asc', 'sorted-desc');
+        if (th.dataset.sortable !== 'false' && th.classList.contains('sortable')) {
+          const ariaValue = (index === idx && direction)
+            ? (direction === 'asc' ? 'ascending' : 'descending')
+            : 'none';
+          th.setAttribute('aria-sort', ariaValue);
+        }
+      });
+    }
+
+    function applySort(index, direction) {
+      let ordered;
+      if (!direction) {
+        ordered = defaultOrder.slice();
+        currentSort.index = null;
+        currentSort.dir = null;
+      } else {
+        const sortType = sortTypes[index] || 'text';
+        ordered = defaultOrder.slice().sort((a, b) => {
+          const aVal = getSortValue(a.cells[index], sortType);
+          const bVal = getSortValue(b.cells[index], sortType);
+          if (aVal < bVal) return direction === 'asc' ? -1 : 1;
+          if (aVal > bVal) return direction === 'asc' ? 1 : -1;
+          return 0;
+        });
+        currentSort.index = index;
+        currentSort.dir = direction;
+      }
+      dataRows = ordered;
+      ordered.forEach(row => tbody.appendChild(row));
+      if (emptyRow) {
+        tbody.appendChild(emptyRow);
+      }
+      setSortIndicators(currentSort.index, currentSort.dir);
+      applyFilters();
+    }
+
+    function toggleSort(index) {
+      if (headers[index].dataset.sortable === 'false') return;
+      let nextDir = 'asc';
+      if (currentSort.index === index) {
+        if (currentSort.dir === 'asc') nextDir = 'desc';
+        else if (currentSort.dir === 'desc') nextDir = null;
+      }
+      applySort(index, nextDir);
+    }
+
+    headers.forEach((th, index) => {
+      const filterType = th.dataset.filter;
+      const sortType = th.dataset.sort || (filterType === 'boolean' ? 'boolean' : 'text');
+      sortTypes[index] = sortType;
+
+      const filterCell = document.createElement('th');
+      filterCell.setAttribute('scope', 'col');
+      filterRow.appendChild(filterCell);
+
+      if (filterType === 'text') {
+        const input = document.createElement('input');
+        input.type = 'search';
+        input.placeholder = 'Filtrar…';
+        input.setAttribute('aria-label', 'Filtrar ' + (th.textContent || '').trim());
+        input.addEventListener('input', applyFilters);
+        filterCell.appendChild(input);
+        filterConfigs.push({ type: 'text', index, getValue: () => input.value });
+      } else if (filterType === 'boolean') {
+        const select = document.createElement('select');
+        select.innerHTML = '<option value="">Todos</option><option value="true">Sí</option><option value="false">No</option>';
+        select.setAttribute('aria-label', 'Filtrar ' + (th.textContent || '').trim());
+        select.addEventListener('change', applyFilters);
+        filterCell.appendChild(select);
+        filterConfigs.push({ type: 'boolean', index, getValue: () => select.value });
+      } else {
+        filterCell.innerHTML = '';
+      }
+
+      if (th.dataset.sortable !== 'false') {
+        th.classList.add('sortable');
+        if (!th.hasAttribute('tabindex')) {
+          th.setAttribute('tabindex', '0');
+        }
+        if (!th.hasAttribute('aria-sort')) {
+          th.setAttribute('aria-sort', 'none');
+        }
+        const handler = (event) => {
+          if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') return;
+          event.preventDefault();
+          toggleSort(index);
+        };
+        th.addEventListener('click', handler);
+        th.addEventListener('keydown', handler);
+      }
+    });
+
+    table.dataset.enhanced = '1';
+    setSortIndicators(currentSort.index, currentSort.dir);
+    applyFilters();
+  }
+
+  function initAll(root) {
+    (root || document).querySelectorAll('table[data-enhanced-list]').forEach(initTable);
+  }
+
+  window.AdminTables = {
+    init: function(root) {
+      initAll(root || document);
+    }
+  };
+
+  if (document.readyState !== 'loading') {
+    initAll(document);
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      initAll(document);
+    });
+  }
+})();

--- a/ligas/static/ligas/admin.css
+++ b/ligas/static/ligas/admin.css
@@ -42,6 +42,20 @@ nav { margin-top:10px; }
 table { width:100%; border-collapse: collapse; }
 th, td { text-align:left; padding:10px; border-bottom:1px solid #e5e7eb; }
 th { background:#f9fafb; color:#374151; }
+.table-filters th { background:#fff; border-bottom:1px solid #e5e7eb; }
+.table-filters input,
+.table-filters select { width:100%; padding:6px 8px; border:1px solid #d1d5db; border-radius:6px; font-size:14px; box-sizing:border-box; }
+.table-filters input { height:32px; }
+.table-filters select { background:#fff; height:34px; }
+th.sortable { cursor:pointer; position:relative; user-select:none; }
+th.sortable::after { content:"↕"; font-size:12px; margin-left:6px; color:#9ca3af; }
+th.sortable.sorted-asc::after { content:"▲"; color:var(--accent); }
+th.sortable.sorted-desc::after { content:"▼"; color:var(--accent); }
+.table-footer { margin-top:16px; display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px; }
+.table-page-size-form { display:flex; align-items:center; gap:6px; font-size:14px; color:#374151; }
+.table-page-size-form label { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.table-page-size-form select { padding:6px 8px; border:1px solid #d1d5db; border-radius:6px; background:#fff; }
+.table-footer .pagination { margin-top:0; }
 .muted { color:#6b7280; }
 .searchbar { display:flex; gap:8px; align-items:center; }
 .searchbar input[type="text"] { padding:8px 10px; border:1px solid #d1d5db; border-radius:6px; min-width: 220px; }

--- a/ligas/templates/ligas/administracion/_table_footer.html
+++ b/ligas/templates/ligas/administracion/_table_footer.html
@@ -1,0 +1,29 @@
+<div class="table-footer">
+  <form method="get" class="table-page-size-form">
+    <label>
+      Mostrar
+      <select name="{{ page_size_query_param }}" onchange="this.form.submit()">
+        {% for option in page_size_options %}
+          <option value="{{ option }}"{% if option == current_page_size %} selected{% endif %}>{{ option }}</option>
+        {% endfor %}
+      </select>
+      entradas
+    </label>
+    {% for key, value in request.GET.items %}
+      {% if key != page_size_query_param and key != 'page' %}
+        <input type="hidden" name="{{ key }}" value="{{ value }}">
+      {% endif %}
+    {% endfor %}
+  </form>
+  {% if is_paginated and page_obj %}
+  <div class="pagination">
+    {% if page_obj.has_previous %}
+      <a href="?{% if pagination_query %}{{ pagination_query }}&{% endif %}page={{ page_obj.previous_page_number }}">« Anterior</a>
+    {% endif %}
+    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+      <a href="?{% if pagination_query %}{{ pagination_query }}&{% endif %}page={{ page_obj.next_page_number }}">Siguiente »</a>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>

--- a/ligas/templates/ligas/administracion/arbitro_list.html
+++ b/ligas/templates/ligas/administracion/arbitro_list.html
@@ -28,20 +28,10 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="3">No hay árbitros.</td></tr>
+      <tr class="empty-row"><td colspan="3">No hay árbitros.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/administracion/categoria_list.html
+++ b/ligas/templates/ligas/administracion/categoria_list.html
@@ -13,9 +13,15 @@
 {% endblock %}
 {% block content %}
   <div id="listContainer">
-  <table>
+  <table data-enhanced-list>
     <thead>
-      <tr><th>Nombre</th><th>Liga</th><th>Activa</th><th>Acciones</th></tr>
+      <tr>
+        <th data-sort="text" data-filter="text">Nombre</th>
+        <th data-sort="text" data-filter="text">Liga</th>
+        <th data-sort="boolean" data-filter="boolean">Activa</th>
+        <th data-sort="boolean" data-filter="boolean">Suma puntos</th>
+        <th data-sortable="false">Acciones</th>
+      </tr>
     </thead>
     <tbody>
       {% for obj in object_list %}
@@ -23,26 +29,17 @@
         <td>{{ obj.nombre }}</td>
         <td>{{ obj.liga }}</td>
         <td>{% if obj.activa %}Sí{% else %}No{% endif %}</td>
+        <td>{% if obj.suma_puntos_general %}Sí{% else %}No{% endif %}</td>
         <td>
           {% if perms.ligas.change_categoria %}<a class="btn js-open-modal" data-modal-title="Editar categoría" href="{% url 'ligas:categoria_update' obj.pk %}">Editar</a>{% endif %}
           {% if perms.ligas.delete_categoria %}<a class="btn danger js-open-modal" data-modal-title="Eliminar categoría" href="{% url 'ligas:categoria_delete' obj.pk %}">Eliminar</a>{% endif %}
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="4">No hay categorías.</td></tr>
+      <tr class="empty-row"><td colspan="5">No hay categorías.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/administracion/club_list.html
+++ b/ligas/templates/ligas/administracion/club_list.html
@@ -27,20 +27,10 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="2">No hay clubes.</td></tr>
+      <tr class="empty-row"><td colspan="2">No hay clubes.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/administracion/equipo_list.html
+++ b/ligas/templates/ligas/administracion/equipo_list.html
@@ -14,9 +14,14 @@
 {% endblock %}
 {% block content %}
   <div id="listContainer">
-  <table>
+  <table data-enhanced-list>
     <thead>
-      <tr><th>Club</th><th>Categoría</th><th>Alias</th><th>Acciones</th></tr>
+      <tr>
+        <th data-sort="text" data-filter="text">Club</th>
+        <th data-sort="text" data-filter="text">Categoría</th>
+        <th data-sort="text" data-filter="text">Alias</th>
+        <th data-sortable="false">Acciones</th>
+      </tr>
     </thead>
     <tbody>
       {% for obj in object_list %}
@@ -31,20 +36,10 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="4">No hay equipos.</td></tr>
+      <tr class="empty-row"><td colspan="4">No hay equipos.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/administracion/jugador_list.html
+++ b/ligas/templates/ligas/administracion/jugador_list.html
@@ -13,9 +13,14 @@
 {% endblock %}
 {% block content %}
   <div id="listContainer">
-  <table>
+  <table data-enhanced-list>
     <thead>
-      <tr><th>Apellido</th><th>Nombre</th><th>Equipo</th><th>Acciones</th></tr>
+      <tr>
+        <th data-sort="text" data-filter="text">Apellido</th>
+        <th data-sort="text" data-filter="text">Nombre</th>
+        <th>Equipo</th>
+        <th data-sortable="false">Acciones</th>
+      </tr>
     </thead>
     <tbody>
       {% for obj in object_list %}
@@ -29,20 +34,10 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="4">No hay jugadores.</td></tr>
+      <tr class="empty-row"><td colspan="4">No hay jugadores.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/administracion/liga_list.html
+++ b/ligas/templates/ligas/administracion/liga_list.html
@@ -28,21 +28,11 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="3">No hay ligas.</td></tr>
+      <tr class="empty-row"><td colspan="3">No hay ligas.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}
 

--- a/ligas/templates/ligas/administracion/ronda_list.html
+++ b/ligas/templates/ligas/administracion/ronda_list.html
@@ -28,20 +28,10 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="3">No hay rondas.</td></tr>
+      <tr class="empty-row"><td colspan="3">No hay rondas.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/administracion/torneo_list.html
+++ b/ligas/templates/ligas/administracion/torneo_list.html
@@ -28,20 +28,10 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="3">No hay torneos.</td></tr>
+      <tr class="empty-row"><td colspan="3">No hay torneos.</td></tr>
       {% endfor %}
     </tbody>
   </table>
-  {% if is_paginated %}
-  <div class="pagination">
-    {% if page_obj.has_previous %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.previous_page_number }}">« Anterior</a>
-    {% endif %}
-    <span class="current">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-      <a href="?q={{ request.GET.q }}&page={{ page_obj.next_page_number }}">Siguiente »</a>
-    {% endif %}
-  </div>
-  {% endif %}
+  {% include 'ligas/administracion/_table_footer.html' %}
   </div>
 {% endblock %}

--- a/ligas/templates/ligas/base_admin.html
+++ b/ligas/templates/ligas/base_admin.html
@@ -185,6 +185,7 @@
       }
     })();
   </script>
+  <script src="{% static 'ligas/admin-tables.js' %}"></script>
   <!-- Modal container -->
   <div id="modalBackdrop" class="modal-backdrop" hidden>
     <div class="modal-window" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
@@ -221,6 +222,9 @@
           const currentList = document.getElementById('listContainer');
           if (newList && currentList) {
             currentList.replaceWith(newList);
+            if (window.AdminTables && typeof window.AdminTables.init === 'function') {
+              window.AdminTables.init(newList);
+            }
           }
         } catch (e) { console.warn('No se pudo refrescar la lista', e); }
       }


### PR DESCRIPTION
## Summary
- allow admin list views to pick per-page sizes via a shared PageSizeMixin and footer include
- add a reusable table footer with page size selector and update list templates with sortable/filterable headers
- style and load a new client-side script that enables column filtering/sorting on enhanced tables

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d3f880d0008325a621dcc5c3c1238a